### PR TITLE
Add note about rosdep for multiple platforms

### DIFF
--- a/documentation/private_repositories.md
+++ b/documentation/private_repositories.md
@@ -46,6 +46,19 @@ The private.yaml will look something like:
 
 You can then _rosdep update_ and run _bloom-release_ as usual.
 
+If you run into an error about a missing dependency for the 'heisenbug'
+distribution when running bloom-release, you will need to add a second line
+for each of your packages, so that it looks like:
+
+        my_private_package1:
+          ubuntu: ros-hydro-my-private-package1
+          fedora: ros-hydro-my-private-package1
+        my_private_package2:
+          ubuntu: ros-hydro-my-private-package2
+          fedora: ros-hydro-my-private-package2
+
+This is because of https://github.com/ros-infrastructure/bloom/issues/296
+
 ###Solution for build time dependencies
 When building and testing the source repositories, there is a horrible hack
 in buildbot-ros, which assumes that any unresolved dependencies are in fact


### PR DESCRIPTION
There is currently a problem with bloom-release when a dependency isn't available for fedora: https://github.com/ros-infrastructure/bloom/issues/296

To work around this, if you want to use bloom-release, it is easiest to add fedora entries in the local rosdep yaml file. This PR adds a note about this in the docs.
