### PR TITLE
Fix crash that happened when commands failed

### DIFF
--- a/scripts/testbuild.py
+++ b/scripts/testbuild.py
@@ -232,12 +232,19 @@ class BuildException(Exception):
         cleanup()
         self.msg = msg
 
+    def __str__(self):
+        return 'BuildException: %s' % self.msg
+
 ## @brief Do some cleanup
 def cleanup():
-    if os.path.exists(workspace+'/build'):
-        shutil.rmtree(workspace+'/build')
-    if os.path.exists(workspace+'/test'):
-        shutil.rmtree(workspace+'/test')
+    try:
+        if os.path.exists(workspace+'/build'):
+            shutil.rmtree(workspace+'/build')
+        if os.path.exists(workspace+'/test'):
+            shutil.rmtree(workspace+'/test')
+    except:
+        # Workspace variable probably didn't exist; do nothing
+        pass
 
 if __name__=="__main__":
     if len(sys.argv) < 3:


### PR DESCRIPTION
When cowbuilder_update imports testbuilder.py and calls functions in it, the global variable "workspace" isn't defined. This causes problems when a command fails, because the BuildException tries to cleanup the workspace. The failure to find the "workspace" variable masks the actual command failure.

There's probably some more extensive changes needed (workspace should probably be passed through all these functions), but this PR does the bare minimum fix so that the user sees what command fails in the traceback.
