### PR TITLE
Missing dependency needed to accomplish docker build and a typo in the readme

### DIFF
--- a/documentation/Dockerfile.example
+++ b/documentation/Dockerfile.example
@@ -25,7 +25,7 @@ RUN easy_install buildbot-slave
 RUN pip install rosdistro
 RUN git clone -b master git@github.com:mikeferguson/buildbot-ros.git /root/buildbot-ros
 RUN buildbot create-master /root/buildbot-ros
-RUN buildslave create-slave /root/rosbuilder1 localhost:9989 rosbuilder1 mebuildsalotaros
+RUN buildslave create-slave /root/rosbuilder1 localhost:9989 rosbuilder1 mebuildsalotros
 
 # Fix the file creation defaults
 RUN cp /root/buildbot-ros/buildbot.tac /root/buildbot-ros/buildbot.tac.bk

--- a/documentation/Dockerfile.example
+++ b/documentation/Dockerfile.example
@@ -19,6 +19,7 @@ RUN apt-get install -q -y debmirror
 RUN virtualenv --no-site-packages /root/buildbot-env
 RUN echo "export PATH=/root/buildbot-ros/scripts:${PATH}" >> /root/buildbot-env/bin/activate
 RUN . /root/buildbot-env/bin/activate
+RUN pip install --upgrade setuptools
 RUN easy_install buildbot
 RUN easy_install buildbot-slave
 RUN pip install rosdistro

--- a/documentation/docker.md
+++ b/documentation/docker.md
@@ -14,7 +14,7 @@ the folder is assumed to be called 'buildbot-ros':
 After building the container, we need to specify a number of bindings
 to make the buildbot work well:
 
-    docker run -d -privileged=true -p 8010:8010 -p 127.0.0.1::22
+    docker run -d --privileged=true -p 8010:8010 -p 127.0.0.1::22
                -v /etc/localtime:/etc/localtime:ro
                -v /var/www/building:/var/www/building:rw
                --name="buildbot-ros" buildbot-ros-image

--- a/master.cfg
+++ b/master.cfg
@@ -49,8 +49,8 @@ c['status'] = []
 c['status'].append(html.WebStatus(http_port=8010, authz=authz_cfg))
 
 # Build Machines
-c['slaves'] = [BuildSlave('rosbuilder1', 'mebuildslotsaros'),
-               BuildSlave('rosbuilder2', 'mebuildslotsaros')]
+c['slaves'] = [BuildSlave('rosbuilder1', 'mebuildsalotros'),
+               BuildSlave('rosbuilder2', 'mebuildsalotros')]
 c['slavePortnum'] = 9989
 BUILDERS = ['rosbuilder1', 'rosbuilder2']
 

--- a/master.cfg
+++ b/master.cfg
@@ -21,7 +21,7 @@ from rosdistro import get_index
 # BuildMasterConfig
 c = BuildmasterConfig = {}
 c['title'] = 'Buildbot-ROS'
-c['titleURL'] = 'http://github.com/mikeferguson/buildbot-ros'
+c['titleURL'] = 'https://github.com/pablo-quilez/buildbot-ros'
 c['buildbotURL'] = "http://localhost:8010/"
 c['builders'] = []
 c['change_source'] = []
@@ -38,12 +38,12 @@ authz_cfg=util.Authz(
     # change any of these to True to enable; see the manual for more options
     auth=util.BasicAuth([("ros","ros")]),
     gracefulShutdown = False,
-    forceBuild = 'auth',
-    forceAllBuilds = False,
-    pingBuilder = False,
-    stopBuild = False,
-    stopAllBuilds = False,
-    cancelPendingBuild = False,
+    forceBuild = True,
+    forceAllBuilds = True,
+    pingBuilder = True,
+    stopBuild = True,
+    stopAllBuilds = True,
+    cancelPendingBuild = True,
 )
 c['status'] = []
 c['status'].append(html.WebStatus(http_port=8010, authz=authz_cfg))


### PR DESCRIPTION
setuptools have to be updated before easy_install buildbot because it seems the newest version is required.